### PR TITLE
Add closeSkipLabels for skip closing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ GitHub action that deals with stale issues in your project.
 
 - `staleLabel` *string*, a label to be set to the stale issue, __default__: `STALE`
 - `staleComment` *string*, a comment placed when marking issue as stale. See a [guide on how to style this message](#styling-close-comment).
+- `closeSkipLabels` *[string]*, list of labels for skip closing the issue
 - `closeComment` *string*, a comment placed when closing issue. See a [guide on how to style this message](#styling-close-comment).
 
 - `showLogs` *bool*. Show logs with info like total number of issues found, stale issues, closed etc. __default__: `true`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GitHub action that deals with stale issues in your project.
 
 - `staleLabel` *string*, a label to be set to the stale issue, __default__: `STALE`
 - `staleComment` *string*, a comment placed when marking issue as stale. See a [guide on how to style this message](#styling-close-comment).
-- `closeSkipLabels` *[string]*, list of labels for skip closing the issue
+- `closeSkipLabels` *string*, comma separated list of labels for skip closing the issue
 - `closeComment` *string*, a comment placed when closing issue. See a [guide on how to style this message](#styling-close-comment).
 
 - `showLogs` *bool*. Show logs with info like total number of issues found, stale issues, closed etc. __default__: `true`

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ jobs:
         closeAfter: 60
         staleLabel: "STALE 📺"
         staleComment: "This issue is %DAYS_OLD% days old, marking as stale! cc: @%AUTHOR%"
+        closeSkipLabels: "priority/P0,priority/P1"
         closeComment: "Issue last updated %DAYS_OLD% days ago! Closing down!"
         showLogs: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,8 @@ inputs:
     required: false
     default: "STALE 📺"
   actionSkipLabels:
-    description: labels to do nothing
+    description: list of labels to do nothing
     required: false
-    default: ""
   staleComment:
     description: a template comment to be placed when handling the issue
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Issue triage'
+name: 'Issue triage customized'
 description: "Deals with stale issues in your project."
 author: "krizzu"
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: label to be set to the stale issue
     required: false
     default: "STALE 📺"
+  actionSkipLabels:
+    description: labels to do nothing
+    required: false
+    default: ""
   staleComment:
     description: a template comment to be placed when handling the issue
     required: false

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   staleComment:
     description: a template comment to be placed when handling the issue
     required: false
+  closeSkipLabels:
+    description: list of labels for skip closing the issue
+    required: false
   closeComment:
     description: a template comment to be placed when closing the issue
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -4611,6 +4611,19 @@ class ActionIssueTriage {
       try {
         let isClosingDown = false;
 
+        let hasActionSkipLabel = false;
+        if (this.opts.actionSkipLabels) {
+          for (const label of issue.labels.map((i) => i.name)) {
+            if (this.opts.actionSkipLabels.split(',').indexOf(label) > 0) {
+              hasActionSkipLabel = true;
+            }
+          }
+        }
+
+        if (hasActionSkipLabel) {
+          continue;
+        }
+
         if (
           this.opts.closeAfter > this.opts.staleAfter &&
           this._isOlderThan(issue.updated_at, this.opts.closeAfter)
@@ -7745,6 +7758,7 @@ const closeAfter = core.getInput('closeAfter') || 0;
 const staleComment = core.getInput('staleComment') || staleCommentDefault;
 const closeComment = core.getInput('staleComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
+const actionSkipLabels = core.getInput('actionSkipLabels') || '';
 const showLogs = core.getInput('showLogs') || 'true';
 
 const GH_TOKEN = core.getInput('ghToken', {
@@ -7759,6 +7773,7 @@ const options = {
   staleComment,
   closeComment,
   staleLabel,
+  actionSkipLabels,
   showLogs: showLogs === 'true',
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4611,9 +4611,19 @@ class ActionIssueTriage {
       try {
         let isClosingDown = false;
 
+        let hasCloseSkipLabel = false;
+        if (this.opts.closeSkipLabels) {
+          for (const label of issue.labels.map((i) => i.name)) {
+            if (this.opts.closeSkipLabels.split(',').indexOf(label) > 0) {
+              hasCloseSkipLabel = true;
+            }
+          }
+        }
+
         if (
           this.opts.closeAfter > this.opts.staleAfter &&
-          this._isOlderThan(issue.updated_at, this.opts.closeAfter)
+          this._isOlderThan(issue.updated_at, this.opts.closeAfter) &&
+          !hasCloseSkipLabel
         ) {
           isClosingDown = true;
         }
@@ -7743,8 +7753,9 @@ const closeCommentDefault = `🤖 Beep Boop 🤖 \n\nThis issue was inactive for
 const staleAfter = core.getInput('staleAfter') || 30;
 const closeAfter = core.getInput('closeAfter') || 0;
 const staleComment = core.getInput('staleComment') || staleCommentDefault;
-const closeComment = core.getInput('staleComment') || closeCommentDefault;
+const closeComment = core.getInput('closeComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
+const closeSkipLabels = core.getInput('closeSkipLabels') || '';
 const showLogs = core.getInput('showLogs') || 'true';
 
 const GH_TOKEN = core.getInput('ghToken', {
@@ -7757,6 +7768,7 @@ const options = {
   staleAfter: +staleAfter,
   closeAfter: +closeAfter,
   staleComment,
+  closeSkipLabels,
   closeComment,
   staleLabel,
   showLogs: showLogs === 'true',

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ const closeCommentDefault = `🤖 Beep Boop 🤖 \n\nThis issue was inactive for
 const staleAfter = core.getInput('staleAfter') || 30;
 const closeAfter = core.getInput('closeAfter') || 0;
 const staleComment = core.getInput('staleComment') || staleCommentDefault;
-const closeComment = core.getInput('staleComment') || closeCommentDefault;
+const closeComment = core.getInput('closeComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
+const closeSkipLabels = core.getInput('closeSkipLabels') || '';
 const showLogs = core.getInput('showLogs') || 'true';
 
 const GH_TOKEN = core.getInput('ghToken', {
@@ -25,6 +26,7 @@ const options = {
   staleAfter: +staleAfter,
   closeAfter: +closeAfter,
   staleComment,
+  closeSkipLabels,
   closeComment,
   staleLabel,
   showLogs: showLogs === 'true',

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const closeAfter = core.getInput('closeAfter') || 0;
 const staleComment = core.getInput('staleComment') || staleCommentDefault;
 const closeComment = core.getInput('staleComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
+const actionSkipLabels = core.getInput('actionSkipLabels') || '';
 const showLogs = core.getInput('showLogs') || 'true';
 
 const GH_TOKEN = core.getInput('ghToken', {
@@ -27,6 +28,7 @@ const options = {
   staleComment,
   closeComment,
   staleLabel,
+  actionSkipLabels,
   showLogs: showLogs === 'true',
 };
 

--- a/src/issueTriage.js
+++ b/src/issueTriage.js
@@ -38,9 +38,19 @@ class ActionIssueTriage {
       try {
         let isClosingDown = false;
 
+        let hasCloseSkipLabel = false;
+        if (this.opts.closeSkipLabels) {
+          for (const label of issue.labels) {
+            if (this.opts.closeSkipLabels.indexOf(label)) {
+              hasCloseSkipLabel = true;
+            }
+          }
+        }
+
         if (
           this.opts.closeAfter > this.opts.staleAfter &&
-          this._isOlderThan(issue.updated_at, this.opts.closeAfter)
+          this._isOlderThan(issue.updated_at, this.opts.closeAfter) &&
+          !hasCloseSkipLabel
         ) {
           isClosingDown = true;
         }

--- a/src/issueTriage.js
+++ b/src/issueTriage.js
@@ -38,6 +38,19 @@ class ActionIssueTriage {
       try {
         let isClosingDown = false;
 
+        let hasActionSkipLabel = false;
+        if (this.opts.actionSkipLabels) {
+          for (const label of issue.labels.map((i) => i.name)) {
+            if (this.opts.actionSkipLabels.split(',').indexOf(label) > 0) {
+              hasActionSkipLabel = true;
+            }
+          }
+        }
+
+        if (hasActionSkipLabel) {
+          continue;
+        }
+
         if (
           this.opts.closeAfter > this.opts.staleAfter &&
           this._isOlderThan(issue.updated_at, this.opts.closeAfter)

--- a/src/issueTriage.js
+++ b/src/issueTriage.js
@@ -40,8 +40,8 @@ class ActionIssueTriage {
 
         let hasCloseSkipLabel = false;
         if (this.opts.closeSkipLabels) {
-          for (const label of issue.labels) {
-            if (this.opts.closeSkipLabels.indexOf(label)) {
+          for (const label of issue.labels.map((i) => i.name)) {
+            if (this.opts.closeSkipLabels.split(',').indexOf(label) > 0) {
               hasCloseSkipLabel = true;
             }
           }


### PR DESCRIPTION
## About

I want to skip close issue only if issue has specific label.

## Chagnes

- Add `closeSkipLabels` option at action.yml
- Check label of issue at 41-48 lines at src/issueTriage.js

## Test

I've test this changes on my local environment by following command.

`yarn build && source .env && node dist/index.js`

It works as expected.