### PR TITLE
Add issueLabels config option to issue-triage-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ GitHub action that deals with stale issues in your project.
 - `staleAfter` *int*, number of days to consider an issue to be stale, __default__: `30`
 - `closeAfter` *int*, number of days after the issue should be closed (0 days means off, must be higher than `staleAfter`), __default__: `0`
 
+- `issueLabels` *string*, comma separated list of labels to filter the issues by (optional)
 - `staleLabel` *string*, a label to be set to the stale issue, __default__: `STALE`
 - `staleComment` *string*, a comment placed when marking issue as stale. See a [guide on how to style this message](#styling-close-comment).
 - `closeComment` *string*, a comment placed when closing issue. See a [guide on how to style this message](#styling-close-comment).
@@ -37,11 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Find old issues and mark them stale
-      uses: Krizzu/issue-triage-action@v1.0.0
+      uses: Krizzu/issue-triage-action@v1.1.0
       with:
         ghToken: ${{ secrets.GITHUB_TOKEN }}
         staleAfter: 30
         closeAfter: 60
+        issueLabels: bug
         staleLabel: "STALE 📺"
         staleComment: "This issue is %DAYS_OLD% days old, marking as stale! cc: @%AUTHOR%"
         closeComment: "Issue last updated %DAYS_OLD% days ago! Closing down!"

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   showLogs:
     description: Show logs with info like total number of issues found, stale issues, closed etc.
     required: false
+  issueLabels:
+    description: comma separated list of labels to filters issues by (issue need to have all the specified labels)
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4693,6 +4693,7 @@ class ActionIssueTriage {
     const issuesPerPage = 100;
 
     const getIssuesForPage = async page => {
+      const labels = this.opts.issueLabels ? { labels: this.opts.issueLabels } : {}
       const { data: issuesResponse } = await this.kit.issues.listForRepo({
         owner: this.opts.repoOwner,
         repo: this.opts.repoName,
@@ -4701,6 +4702,7 @@ class ActionIssueTriage {
         direction: 'desc',
         per_page: issuesPerPage,
         page,
+        ...labels
       });
 
       return issuesResponse.filter(this._isIssue);
@@ -7746,6 +7748,7 @@ const staleComment = core.getInput('staleComment') || staleCommentDefault;
 const closeComment = core.getInput('staleComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
 const showLogs = core.getInput('showLogs') || 'true';
+const issueLabels = core.getInput('issueLabels');
 
 const GH_TOKEN = core.getInput('ghToken', {
   required: true,
@@ -7760,6 +7763,7 @@ const options = {
   closeComment,
   staleLabel,
   showLogs: showLogs === 'true',
+  issueLabels
 };
 
 const action = new ActionIssueTriage(new github.GitHub(GH_TOKEN), options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krizzu/issue_triage_action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Github action that finds and handles old issues in project",
   "main": "dist/index.js",
   "author": "Krzysztof Borowy <dev@krizzu.dev>",

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const staleComment = core.getInput('staleComment') || staleCommentDefault;
 const closeComment = core.getInput('staleComment') || closeCommentDefault;
 const staleLabel = core.getInput('staleLabel') || 'STALE';
 const showLogs = core.getInput('showLogs') || 'true';
+const issueLabels = core.getInput('issueLabels');
 
 const GH_TOKEN = core.getInput('ghToken', {
   required: true,
@@ -28,6 +29,7 @@ const options = {
   closeComment,
   staleLabel,
   showLogs: showLogs === 'true',
+  issueLabels
 };
 
 const action = new ActionIssueTriage(new github.GitHub(GH_TOKEN), options);

--- a/src/issueTriage.js
+++ b/src/issueTriage.js
@@ -120,6 +120,7 @@ class ActionIssueTriage {
     const issuesPerPage = 100;
 
     const getIssuesForPage = async page => {
+      const labels = this.opts.issueLabels ? { labels: this.opts.issueLabels } : {}
       const { data: issuesResponse } = await this.kit.issues.listForRepo({
         owner: this.opts.repoOwner,
         repo: this.opts.repoName,
@@ -128,6 +129,7 @@ class ActionIssueTriage {
         direction: 'desc',
         per_page: issuesPerPage,
         page,
+        ...labels
       });
 
       return issuesResponse.filter(this._isIssue);


### PR DESCRIPTION
Adds a issueLabels configuration option to allow to filter issues by
labels. It's a comma separated list of labels, eg. "label1,label2,label3"
Issue needs to have all the specified labels.

Example use case:
Create different rules for staleness/closing per issue "type". eg.

```yml
name: Issue cleanup
on:
  schedule:
    - cron: '0 1 * * *' # Every day at 1am
jobs:
  triage_issues:
    name: Issue triage
    runs-on: ubuntu-latest
    steps:
    - name: Mark stale bugs
      uses: Krizzu/issue-triage-action@v1.1.0
      with:
        ghToken: ${{ secrets.GITHUB_TOKEN }}
        issueLabels: "bug"
        staleAfter: 7
        closeAfter: 0
        staleLabel: "stale"
        staleComment: "This issue is %DAYS_OLD% days old, marking as overdue!"
        closeComment: "Issue last updated %DAYS_OLD% days ago! Closing down!"
        showLogs: true
    - name: Close stale feature requests
      uses: Krizzu/issue-triage-action@v1.1.0
      with:
        ghToken: ${{ secrets.GITHUB_TOKEN }}
        issueLabels: "features"
        staleAfter: 14
        closeAfter: 30
        staleLabel: "stale"
        staleComment: "This issue is %DAYS_OLD% days old, marking as overdue!"
        closeComment: "Issue last updated %DAYS_OLD% days ago! Closing down!"
        showLogs: true
```